### PR TITLE
Correct a pose triggered by turning under water physics

### DIFF
--- a/src/config.asm
+++ b/src/config.asm
@@ -1,14 +1,8 @@
 org $CEFF00
 config_flags:
 ; Multiworld enabled 
-config_multiworld: ; $CEFF00
+config_multiworld:  ; $CEFF00
     dw $0000
 ; Custom sprite used
 config_sprite: ; $CEFF02
     dw $0000
-
-
-; Custom sprite engine flags
-org $B4F500
-config_screwattack: ; $B4F500
-    dw #$0000

--- a/src/sprite/config.asm
+++ b/src/sprite/config.asm
@@ -1,0 +1,4 @@
+org $9B93FE
+
+config_screw_attack:
+    dw #$0000

--- a/src/sprite/gunport.asm
+++ b/src/sprite/gunport.asm
@@ -5,11 +5,11 @@
 ; memory since Deerforce were very wasteful in this section.
 
 ; $90:C7A5 has pointers to the gun port DMA locations. The now free space at
-; $90:86A3-87BC will be used for a table to DMA sets for all ten directions.
+; $90:86AF-87BC will be used for a table to DMA sets for all ten directions.
 
 gun_port_dma = $9A9A00
 
-org $9086A3
+org $9086AF
 
 gun_port_table:
 

--- a/src/sprite/spinjump.asm
+++ b/src/sprite/spinjump.asm
@@ -4,34 +4,30 @@
 ; First off, we need a new control code that checks for space jump, so that we
 ; can gate the animation appropriately.
 
-; Relocated this to freespace at the end of bank 90 to fit and not overwrite things.   -total
-org $90F640
+org $908688
 control_code_routine:
-    LDA config_screwattack  
-    BEQ .config_disabled
-    
-    LDA $09A2       ; get item equipped info
-    BIT #$0200      ; check for space jump equipped
-    BNE .space_jump ; if space jump, branch to space jump stuff
-    LDA $0A96       ; get the pose number
-    CLC             ; prepare to do math
-    ADC #$001B      ; skip past the old screw attack to the new stuff
-    BRA .exit       ; then exit after doing some important things after branching
+    LDA $09A2           ; get item equipped info
+    BIT #$0200          ; check for space jump equipped
+    BNE .screw_attack   ; if space jump, branch to space jump stuff
+    LDA.l config_screw_attack
+    BEQ .screw_attack   ; if disabled, do regular screw attack animation (if branch taken, uses one more clock cycle)
 
-.config_disabled
-    LDA $09A2       ; This code is here just to make sure both implementations 
-    BIT #$0200      ; uses the same amount of clock cycles for pose selection
-    BNE .space_jump
-    NOP : XBA       
+.spin_attack:
+    LDA.l $7E0A96       ; get the pose number (LDA.l here to add one more clock cycle to preserve timing)
+    CLC                 ; prepare to do math
+    ADC #$001B          ; skip past the old screw attack to the new stuff
+    BRA .exit           ; then prepare to end subroutine
 
-.space_jump:
-    LDA $0A96       ; get the pose number
-    INC A           ; just go to the next pose
+.screw_attack
+    LDA $0A96           ; get the pose number
+    CLC                 ; prepare to do math
+    ADC #$0001          ; just add one to go to the old screw attack (instead of INC to preserves timing)
+    BRA .exit           ; then prepare to end subroutine (could skip, but timing)
 
 .exit:
-    STA $0A96       ; store the new pose in the correct spot
-    TAY             ; transfer to Y because reasons
-    SEC             ; flag the carry bit because reasons
+    STA $0A96           ; store the new pose in the correct spot
+    TAY                 ; transfer to Y because reasons
+    SEC                 ; flag the carry bit because reasons
     RTS
 
 
@@ -136,52 +132,54 @@ org $909DD4
 
 org $9B8000
 conditional_pose_routine:
-    LDA $09A2         ; get equipped items
-    BIT #$0020        ; check for gravity suit
-    BNE .equip_check  ; if gravity suit, underwater status is not important
-    JSL $90EC58       ; $12 / $14 = Samus' bottom / top boundary position
-    LDA $195E         ; get [FX Y position]
-    BMI .acid_check   ; if [FX Y position] < 0:, need to check for acid
-    CMP $14           ; check FX Y position against Samus's position
-    BPL .equip_check  ; above water, so underwater status is not important
-    LDA $197E         ; get physics flag
-    BIT #$0004        ; if liquid physics are disabled, underwater status is not important
+    LDA $09A2           ; get equipped items
+    BIT #$0020          ; check for gravity suit
+    BNE .equip_check    ; if gravity suit, underwater status is not important
+    JSL $90EC58         ; $12 / $14 = Samus' bottom / top boundary position
+    LDA $195E           ; get [FX Y position]
+    BMI .acid_check     ; if [FX Y position] < 0:, need to check for acid
+    CMP $14             ; check FX Y position against Samus's position
+    BPL .equip_check    ; above water, so underwater status is not important
+    LDA $197E           ; get physics flag
+    BIT #$0004          ; if liquid physics are disabled, underwater status is not important
     BNE .equip_check
-    BRA .first_pose   ; ok, you're probably underwater at this point
+    BRA .underwater     ; ok, you're probably underwater at this point
 
 .acid_check:
     LDA $1962
-    BMI .equip_check  ; if [lava/acid Y position] < 0, then there is no acid, so underwater status is not important
+    BMI .equip_check    ; if [lava/acid Y position] < 0, then there is no acid, so underwater status is not important
     CMP $14
-    BMI .first_pose   ; if [lava/acid Y position] < Samus' top boundary position, then you are underwater
+    BMI .underwater     ; if [lava/acid Y position] < Samus' top boundary position, then you are underwater
 
 .equip_check:
-    LDA $09A2         ; get equipped items
-    BIT #$0008        ; check for screw attack equipped
-    BEQ .first_pose   ; if screw attack not equipped, branch out
-    BIT #$0200        ; check for space jump
-    BEQ .spin_attack  ; if space jump not equipped, branch out
+    LDA $09A2           ; get equipped items
+    BIT #$0008          ; check for screw attack equipped
+    BEQ .first_pose     ; if screw attack not equipped, just do normal advance
+    BIT #$0200          ; check for space jump
+    BEQ .spin_attack    ; if space jump not equipped, branch out
 
 .screw_attack:
-    LDA #$0002        ; default to (new) second pose
-    STA $0A9A
-    RTL
-
-.first_pose:
-    LDA #$0001        ; default to first pose, as in classic
+    LDA #$0002          ; default to (new) second pose
     STA $0A9A
     RTL
 
 .spin_attack:
-    LDA config_screwattack  
-    BEQ +
-    LDA #$001C        ; skip over to our new spin attack section
+    LDA.l config_screw_attack
+    BEQ .screw_attack   ; if disabled, do regular screw attack animation (if branch taken, uses one more clock cycle)
+    LDA #$001C          ; skip over to our new spin attack section
+    STA.l $7E0A9A       ; (STA.l here to add one more clock cycle to preserve timing)
+    RTL
+
+.first_pose:
+    LDA #$0001          ; default to first pose, as in classic
     STA $0A9A
     RTL
-+
-    LDA #$0002
-    STA $0A9A
-    RTL
+
+.underwater             ; figure out if Samus jumped into, or is in, the water, by checking for animation $81 or $82
+    LDA $0A1C           ; get animation #
+    BIT #$0080          ; check for animations $81, $82
+    BEQ .first_pose     ; if not, then just do normal stuff
+    BRA .equip_check    ; but if so, we have to go through all the normal checks
 
 
 ; Hook the subroutine

--- a/src/sprite/sprite.asm
+++ b/src/sprite/sprite.asm
@@ -5,6 +5,8 @@
 ; - https://github.com/Artheau/SpriteSomething/blob/v1.0.659/source/metroid3/rom.py
 ; - https://github.com/Artheau/SpriteSomething/blob/v1.0.659/source/metroid3/samus/rom_export.py
 
+incsrc "config.asm"
+
 incsrc "bugfixes.asm"
 incsrc "improvements.asm"
 


### PR DESCRIPTION
With Screw attack, or Screw attack and Space jump equipped, trying to turn under the effect of water physics (in or into water without Gravity equipped) would trigger a static frame from the Space jump spin animation. This commit fixes this and makes the following changes of importance:

- The gun port table is moved and starts at $90:86AF .
- The address for the screw attack behavior flag is moved to $9B:93FE
  - Since this is at the end of space for the former vanilla death animation poses, the flag is now specified in src/sm/sprite/config.asm rather than src/sm/config.asm .
  - Given that this is in the same bank as of one of the routines, we explicitly use the `LDA.l` opcode to make sure the long version is used.
- The long version of `LDA` and `STA` opcodes are also used for timing neutrality between branches that pertain to the effect of the screw attack flag.